### PR TITLE
Updated Server

### DIFF
--- a/src/server/src/migrations/20180000000000-create-header.js
+++ b/src/server/src/migrations/20180000000000-create-header.js
@@ -14,10 +14,12 @@ module.exports = {
             },
             createdAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             },
             updatedAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             }
         });

--- a/src/server/src/migrations/20180000000001-create-grid.js
+++ b/src/server/src/migrations/20180000000001-create-grid.js
@@ -28,10 +28,12 @@ module.exports = {
             },
             createdAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             },
             updatedAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             }
         });

--- a/src/server/src/migrations/20180000000001-create-instructor.js
+++ b/src/server/src/migrations/20180000000001-create-instructor.js
@@ -40,10 +40,12 @@ module.exports = {
             },
             createdAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             },
             updatedAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             }
         });

--- a/src/server/src/migrations/20180000000001-create-lesson.js
+++ b/src/server/src/migrations/20180000000001-create-lesson.js
@@ -29,10 +29,12 @@ module.exports = {
             },
             createdAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             },
             updatedAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             }
         });

--- a/src/server/src/migrations/20180000000002-create-instructor-preference.js
+++ b/src/server/src/migrations/20180000000002-create-instructor-preference.js
@@ -35,10 +35,12 @@ module.exports = {
             },
             createdAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             },
             updatedAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             }
         });

--- a/src/server/src/migrations/20180000000002-create-private.js
+++ b/src/server/src/migrations/20180000000002-create-private.js
@@ -40,10 +40,12 @@ module.exports = {
             },
             createdAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             },
             updatedAt: {
                 allowNull: false,
+                defaultValue: Date.now(),
                 type: Sequelize.DATE
             }
         });


### PR DESCRIPTION
Updated Sequelize not automatically generating values fo createdAt and updatedAt on initialization.

References issue: None.

This pull request modifies:
 * Updated Sequelize not automatically generating values fo createdAt and updatedAt on initialization.

Mentions (reviewer, co-contributor, etc.): @istreight 
