### PR TITLE
Fix PDF generation

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -5,11 +5,9 @@
     "main": "index.app.js",
     "dependencies": {
         "@babel/polyfill": "^7.12.1",
-        "@types/jquery": "^3.5.5",
         "@types/jspdf": "^1.3.3",
         "@types/react": "^17.0.1",
         "@types/react-dom": "^17.0.0",
-        "jquery": "^3.5.1",
         "jspdf": "^2.3.0",
         "jspdf-autotable": "^3.5.13",
         "n": "^7.0.1",

--- a/src/app/src/components/Controller.js
+++ b/src/app/src/components/Controller.js
@@ -254,7 +254,6 @@ class Controller extends React.Component {
             if (this.state.components[name] !== undefined) {
                 /*
                  * Updated InstructorPreferences to store class members in state and use utility and specialized components.
-                 * Eliminated jQuery from InstructorPreferences.
                  * Update Controller and Connector to reflect changes in InstructorPreferences.
                  */
                 if (name === "instructorPreferences") {

--- a/src/app/src/components/Grid.js
+++ b/src/app/src/components/Grid.js
@@ -898,7 +898,7 @@ class Grid extends React.Component {
     exportToPDF() {
         var header = this.props.getSetTitle();
         var exporter = new ExportToPDF();
-        exporter.pdf(header, this.state.data.lessonTimes);
+        exporter.pdf(header);
     }
 
     /**


### PR DESCRIPTION
In addition to a few code structure changes (removal of jQuery, "var", etc.), this commit responds to the changes in an update of jsPDF-autotable and allows Grids to be exported as PDF as designed

References issue #.

This pull request modifies:
 * Export Grids as PDF (again!)
 * Purge jQuery
 *

Mentions (reviewer, co-contributor, etc.): @istreight
